### PR TITLE
add .gitlab-ci.yml with Vagrantfile for easy reproducible builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ iOSInjectionProject/
 
 # No IntelliJ stuff.
 .idea
+
+# Vagrant
+.vagrant

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,61 @@
+
+# set up apt for automated use
+.apt-template: &apt-template
+- export LC_ALL=C.UTF-8
+- export DEBIAN_FRONTEND=noninteractive
+- echo Etc/UTC > /etc/timezone
+- echo 'quiet "1";'
+       'APT::Install-Recommends "0";'
+       'APT::Install-Suggests "0";'
+       'APT::Acquire::Retries "20";'
+       'APT::Get::Assume-Yes "true";'
+       'Dpkg::Use-Pty "0";'
+      > /etc/apt/apt.conf.d/99gitlab
+- apt-get update
+- apt-get dist-upgrade
+
+
+# -- jobs ------------------------------------------------------------
+
+android:
+  image: debian:bullseye-backports
+  variables:
+    ANDROID_HOME: /usr/lib/android-sdk
+    GOPATH: "/go"
+    LANG: C.UTF-8
+    PATH: "/go/bin:/usr/lib/go-1.16/bin:/usr/bin:/bin"
+    REPRODUCIBLE_FLAGS: -trimpath -ldflags=-buildid=
+  artifacts:
+    name: "${CI_PROJECT_PATH}_${CI_JOB_STAGE}_${CI_JOB_ID}_${CI_COMMIT_REF_NAME}_${CI_COMMIT_SHA}"
+    paths:
+      - IPtProxy*
+    expire_in: 1 week
+    when: on_success
+  before_script:  # things that need root go here, to support the Vagrant setup
+    - *apt-template
+    - apt-get install
+        android-sdk-platform-23
+        android-sdk-platform-tools
+        build-essential
+        curl
+        default-jdk-headless
+        git
+        gnupg
+        unzip
+        wget
+    - apt-get install -t bullseye-backports golang-1.16
+
+    - ndk=android-ndk-r21e-linux-x86_64.zip
+    - wget --continue --no-verbose https://dl.google.com/android/repository/$ndk
+    - echo "ad7ce5467e18d40050dc51b8e7affc3e635c85bd8c59be62de32352328ed467e  $ndk" > $ndk.sha256
+    - sha256sum -c $ndk.sha256
+    - unzip -q $ndk
+    - rm ${ndk}*
+    - mv android-ndk-* $ANDROID_HOME/ndk-bundle/
+    - export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle/
+
+    - chmod -R a+rX $ANDROID_HOME
+
+  script:
+    - find -name '*.[ja]ar' -delete
+    - ./build-android.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,66 @@
+require 'pathname'
+require 'tempfile'
+require 'yaml'
+
+srvpath = Pathname.new(File.dirname(__FILE__)).realpath
+configfile = YAML.load_file(File.join(srvpath, "/.gitlab-ci.yml"))
+remote_url = 'https://gitlab.com/guardianproject/IPtProxy.git'
+
+# set up essential environment variables
+env = configfile['android']['variables']
+env['CI_PROJECT_DIR'] = '/builds/guardianproject/IPtProxy'
+env_file = Tempfile.new('env')
+File.chmod(0644, env_file.path)
+env.each do |k,v|
+    env_file.write("export #{k}='#{v}'\n")
+end
+env_file.rewind
+
+sourcepath = '/etc/profile.d/env.sh'
+header = "#!/bin/bash -ex\nsource #{sourcepath}\ncd $CI_PROJECT_DIR\n"
+
+before_script_file = Tempfile.new('before_script')
+File.chmod(0755, before_script_file.path)
+before_script_file.write(header)
+configfile['android']['before_script'].flatten.each do |line|
+    before_script_file.write(line)
+    before_script_file.write("\n")
+end
+before_script_file.rewind
+
+script_file = Tempfile.new('script')
+File.chmod(0755, script_file.path)
+script_file.write(header)
+configfile['android']['script'].flatten.each do |line|
+    script_file.write(line)
+    script_file.write("\n")
+end
+script_file.rewind
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "debian/bullseye64"
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+  config.vm.provision "file", source: env_file.path, destination: 'env.sh'
+  config.vm.provision :shell, inline: <<-SHELL
+    set -ex
+    mv ~vagrant/env.sh #{sourcepath}
+    source #{sourcepath}
+    test -d /go || mkdir /go
+    mkdir -p $(dirname $CI_PROJECT_DIR)
+    chown -R vagrant.vagrant $(dirname $CI_PROJECT_DIR)
+    apt-get update
+    apt-get -qy install --no-install-recommends git
+    git clone #{remote_url} $CI_PROJECT_DIR
+    chmod -R a+rX,u+w /go $CI_PROJECT_DIR
+    chown -R vagrant.vagrant /go $CI_PROJECT_DIR
+SHELL
+  config.vm.provision "file", source: before_script_file.path, destination: 'before_script.sh'
+  config.vm.provision "file", source: script_file.path, destination: 'script.sh'
+  config.vm.provision :shell, privileged: true, inline: '/home/vagrant/before_script.sh'
+  config.vm.provision :shell, privileged: false, inline: '/home/vagrant/script.sh'
+
+  # remove this or comment it out to use VirtualBox instead of libvirt
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.memory = 1536
+  end
+end


### PR DESCRIPTION
Ths uses the reprducibly-built Debian packages whenever possible to go for the full reproducible stack!

This is the same process as:
https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/merge_requests/6

You can test it locally using: `vagrant up` or see it in action here:
https://gitlab.com/eighthave/IPtProxy/-/pipelines/423528830