### PR TITLE
Snowflake Proxy Work 

### DIFF
--- a/IPtProxy.go/IPtProxy.go
+++ b/IPtProxy.go/IPtProxy.go
@@ -224,7 +224,10 @@ func StopSnowflake() {
 	snowflakeRunning = false
 }
 
-type ClientConnectedDelegate interface {
+// SnowflakeClientConnectedDelegate - Delegate for use when clients connect
+// to the snowflake proxy. For use with StartSnowflakeProxy
+type SnowflakeClientConnectedDelegate interface {
+	// Connected - callback method to handle snowflake proxy client connections
 	Connected()
 }
 
@@ -244,10 +247,10 @@ type ClientConnectedDelegate interface {
 //
 // @param unsafeLogging Prevent logs from being scrubbed.
 //
-// @param clientConnected A delegate which is called when a client successfully connected. Will be called on its own thread!
+// @param onClientConnectedDelegate A delegate which is called when a client successfully connected. Will be called on its own thread! OPTIONAL 
 //
 //goland:noinspection GoUnusedExportedFunction
-func StartSnowflakeProxy(capacity int, broker, relay, stun, logFile string, keepLocalAddresses, unsafeLogging bool, delegate ClientConnectedDelegate) {
+func StartSnowflakeProxy(capacity int, broker, relay, stun, logFile string, keepLocalAddresses, unsafeLogging bool, onClientConnectedDelegate SnowflakeClientConnectedDelegate) {
 	if snowflakeProxy != nil {
 		return
 	}
@@ -263,8 +266,8 @@ func StartSnowflakeProxy(capacity int, broker, relay, stun, logFile string, keep
 		KeepLocalAddresses: keepLocalAddresses,
 		RelayURL:           relay,
 		ClientConnectedCallback: func() {
-			if delegate != nil {
-				delegate.Connected()
+			if onClientConnectedDelegate != nil {
+				onClientConnectedDelegate.Connected()
 			}
 		},
 	}

--- a/IPtProxy.go/IPtProxy.go
+++ b/IPtProxy.go/IPtProxy.go
@@ -274,7 +274,7 @@ func StartSnowflakeProxy(capacity int, broker, relay, stun, logFile string, keep
 
 	fixEnv()
 
-	go func(snowflakeProxy sfp.SnowflakeProxy) {
+	go func(snowflakeProxy *sfp.SnowflakeProxy) {
 		var logOutput io.Writer = os.Stderr
 		log.SetFlags(log.LstdFlags | log.LUTC)
 
@@ -299,7 +299,7 @@ func StartSnowflakeProxy(capacity int, broker, relay, stun, logFile string, keep
 		if err != nil {
 			log.Fatal(err)
 		}
-	}(*snowflakeProxy)
+	}(snowflakeProxy)
 }
 
 // StopSnowflakeProxy - Stop the Snowflake proxy.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ allprojects {
 }
 ```
 
+For newer Android Studio projects created in <a href="https://developer.android.com/studio/preview/features?hl=hu#settings-gradle">Android Studio Bumblebee | 2021.1.1 or newer</a>, the jitpack repository needs to be added into the root level file `settings.gradle` instead of `build.gradle`:
+
+```groovy
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+	// ...
+        maven { url 'https://jitpack.io' }
+    }
+}
+```
+
+
+
 ### Getting Started
 
 If you are building a new Android application be sure to declare that it uses the
@@ -130,7 +144,7 @@ if you don't want to rely on CocoaPods.
 
 Make sure that `javac` is in your `$PATH`. If you do not have a JDK instance, on Debian systems you can install it with 
 ```bash
-apt install default-jdk
+apt install default-jdk 
 ````
 
 If they aren't already, make sure the `$ANDROID_HOME` and `$ANDROID_NDK_HOME` 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ if you don't want to rely on CocoaPods.
 
 ### Android
 
+Make sure that `javac` is in your `$PATH`. If you do not have a JDK instance, on Debian systems you can install it with 
+```bash
+apt install default-jdk
+````
+
 If they aren't already, make sure the `$ANDROID_HOME` and `$ANDROID_NDK_HOME` 
 environment variables are set:
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ And this to your root `build.gradle` at the end of repositories:
 ```groovy
 allprojects {
 	repositories {
-		...
+		// ...
 		maven { url 'https://jitpack.io' }
 	}
 }
@@ -77,7 +77,7 @@ For newer Android Studio projects created in <a href="https://developer.android.
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-	// ...
+	  // ...
         maven { url 'https://jitpack.io' }
     }
 }


### PR DESCRIPTION
This makes the snowflake proxy start and stop again. I added doc strings to the new properties that you created recently. Also updated the building documentation with things I ran into getting IPtProxy hooked into a new Android project. 

I noticed that the callback function does not work when the snowflake proxy logs "Connection successful.". I started looking into this but the coffee shop I connect to the Internet in is about to close so this remains unfinished. 

As far as the callback works, I did notice this. I locally created a go function Test that takes a `SnowflakeClientConnectedDelegate`. In Kotlin/Java I call it and immediately the callback fires off in Androidworld. This leads me to suspect that the callback isn't working because it is being invoked from within a go routine on another thread and this somehow severs the interface back to the Android app.  

This code can be tested against the android app here: https://github.com/bitmold/TestSnowflakeProxy - I haven't yet ran any of this code in Orbot yet 