### PR TITLE
Missing natProbe Param in Doc Strings 

### DIFF
--- a/IPtProxy.go/IPtProxy.go
+++ b/IPtProxy.go/IPtProxy.go
@@ -242,7 +242,7 @@ type SnowflakeClientConnected interface {
 //
 // @param stun STUN URL. OPTIONAL. Defaults to stun:stun.stunprotocol.org:3478, if empty.
 //
-// @param natProbe. OPTIONAL. Defaults to https://snowflake-broker.torproject.net:8443/probe, if empty.
+// @param natProbe OPTIONAL. Defaults to https://snowflake-broker.torproject.net:8443/probe, if empty.
 //
 // @param logFile Name of log file. OPTIONAL. Defaults to STDERR.
 //


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22125581/149435614-8fd22c9d-6482-4381-bd8f-0c376a04cf71.png)

Android Studio won't show the documentation string for the `natProbe` argument because the parameter name had a period character.

Of course, if you look at the actual java doc text it will be there, but not by default:
![image](https://user-images.githubusercontent.com/22125581/149435707-a49e49a8-9334-464e-a367-ce0877292048.png)
