### PR TITLE
function for if snowflake proxy is running

### DIFF
--- a/IPtProxy.go/IPtProxy.go
+++ b/IPtProxy.go/IPtProxy.go
@@ -361,3 +361,8 @@ func IsPortAvailable(port int) bool {
 
 	return false
 }
+
+// IsSnowflakeProxyRunning - Checks to see if a snowflake proxy is running in your app
+func IsSnowflakeProxyRunning() bool {
+	return snowflakeProxy != nil
+}


### PR DESCRIPTION
Could you please create a release 1.5.1 so I can use this within Orbot.

I remember in the past once wanting this, and then later on deeming it unnecessary (as implementing apps could just keep track of if the Snowflake Proxy is running or not), but today I found a use case for this:

If you have an Android app with an Activity for user interaction, and a background service that runs the snowflake proxy, it's actually really complicated for the implementor to keep the state consistent across the service and the activity. (The service would have to first track if the proxy is running, and then send messages between the service + activity). Since both activity and service ultimately access the same go struct `snowflakeProxy` having an is running function in IPtProxy removes this complexity and keeps things very simple for me. 