### PR TITLE
expose obfs4Proxy version to integrating apps

### DIFF
--- a/IPtProxy.go/IPtProxy.go
+++ b/IPtProxy.go/IPtProxy.go
@@ -91,6 +91,9 @@ func init() {
 	StateLocation += "/pt_state"
 }
 
+// Obfs4ProxyVersion - the version of obfs4Proxy bundled with IPtProxy
+const Obfs4ProxyVersion = obfs4proxy.obfs4proxyVersion
+
 // StartObfs4Proxy - Start the Obfs4Proxy.
 //
 // This will test, if the default ports are available. If not, it will increment them until there is.


### PR DESCRIPTION
Would be nice to show in Orbot ~ Snowflake doesn't explicitly define a version in its codebase. I'm not sure if there is a way to reflexively obtain this information from the go module