### PR TITLE
New args needed for snowflake proxy 2.3.0

### DIFF
--- a/IPtProxy.go/IPtProxy.go
+++ b/IPtProxy.go/IPtProxy.go
@@ -310,6 +310,8 @@ func StartSnowflakeProxy(capacity int, broker, relay, stun, natProbe, logFile st
 		RelayURL:           relay,
 		NATProbeURL:        natProbe,
 		ProxyType:          "iptproxy",
+		RelayDomainNamePattern: "snowflake.torproject.net$",
+		AllowNonTLSRelay: false,
 		ClientConnectedCallback: func() {
 			if clientConnected != nil {
 				clientConnected.Connected()


### PR DESCRIPTION
Turns out snowflake proxy 2.3.0 added new proxy arguments. These are the defaults from the command line program included in the snowflake repository. 