### PR TITLE
Add -trimpath to gomobile bind

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,6 +54,6 @@ cd IPtProxy.go || exit 1
 
 gomobile init
 
-MACOSX_DEPLOYMENT_TARGET=11.0 gomobile bind -target=$TARGET -o ../$OUTPUT -iosversion 11.0 -androidapi 19 -v -tags netcgo
+MACOSX_DEPLOYMENT_TARGET=11.0 gomobile bind -target=$TARGET -o ../$OUTPUT -trimpath -iosversion 11.0 -androidapi 19 -v -tags netcgo
 
 printf '\n\n--- Done.\n\n'


### PR DESCRIPTION
Just added this to OrbotLib, when you use `go build` (or `gomobile bind`) the binary contains full filepaths which you probably don't want (might leak information about the setup of your development machine)

For free it also produces a slightly smaller binary with no performance tradeoffs (in my case ~30KB) 

``` 
-trimpath
                remove all file system paths from the resulting executable.
                Instead of absolute file system paths, the recorded file names
                will begin either a module path@version (when using modules),
                or a plain import path (when using the standard library, or GOPATH).
```