### PR TITLE
Temp directory improvments

### DIFF
--- a/IPtProxy.go/IPtProxy.go
+++ b/IPtProxy.go/IPtProxy.go
@@ -10,8 +10,6 @@ import (
 	"log"
 	"net"
 	"os"
-	"path/filepath"
-	"runtime"
 	"strconv"
 	"time"
 )

--- a/IPtProxy.go/IPtProxy.go
+++ b/IPtProxy.go/IPtProxy.go
@@ -84,13 +84,13 @@ var snowflakeProxy *sfp.SnowflakeProxy
 var StateLocation string
 
 func init() {
-	if runtime.GOOS == "android" {
-		StateLocation = "/data/local/tmp"
-	} else {
-		StateLocation = os.Getenv("TMPDIR")
+	tempDir, err := os.MkdirTemp("", "pt_state-*")
+
+	if err != nil {
+		log.Fatal(err)
 	}
 
-	StateLocation = filepath.Join(StateLocation, "pt_state")
+	StateLocation = tempDir
 }
 
 // Obfs4ProxyVersion - The version of Obfs4Proxy bundled with IPtProxy.


### PR DESCRIPTION
We recently had a security audit conducted on our code, we have a fork of IPtProxy called IEnvoyProxy (thank you, your code has been a big help), and they called out a Low severity issue with the temp file location used by IEnvoyProxy/IPtProxy. This is how I fixed in our code, using `os.MkdirTemp`

I'm still kind of new to Go and mobile dev, but this looks like the right way to do it in 2023. os.MkdirTemp was added in go 1.16, and it looks like that's the minimum version required by IPtProxy, so that shouldn't be a problem.
