### PR TITLE
Update lyrebird patch to properly show version string

### DIFF
--- a/lyrebird.patch
+++ b/lyrebird.patch
@@ -1,8 +1,8 @@
 diff --git a/cmd/lyrebird/lyrebird.go b/cmd/lyrebird/lyrebird.go
-index 29c51a3..1555ef6 100644
+index 29c51a3..3a24450 100644
 --- a/cmd/lyrebird/lyrebird.go
 +++ b/cmd/lyrebird/lyrebird.go
-@@ -27,17 +27,16 @@
+@@ -27,10 +27,9 @@
  
  // Go language Tor Pluggable Transport suite.  Works only as a managed
  // client/server.
@@ -11,10 +11,10 @@ index 29c51a3..1555ef6 100644
  
  import (
 -	"flag"
--	"fmt"
+ 	"fmt"
  	"io"
  	golog "log"
- 	"net"
+@@ -38,6 +37,7 @@ import (
  	"net/url"
  	"os"
  	"path"
@@ -22,11 +22,11 @@ index 29c51a3..1555ef6 100644
  	"sync"
  	"syscall"
  
-@@ -52,13 +51,14 @@ import (
+@@ -52,13 +52,14 @@ import (
  const (
  	lyrebirdLogFile = "lyrebird.log"
  	socksAddr       = "127.0.0.1:0"
-+	LyrebirdVersion   = "0.2.0"
++	LyrebirdVersion = "0.2.0"
 +	LyrebirdLogFile = lyrebirdLogFile
  )
  
@@ -39,7 +39,7 @@ index 29c51a3..1555ef6 100644
  	ptClientInfo, err := pt.ClientSetup(transports.Transports())
  	if err != nil {
  		golog.Fatal(err)
-@@ -85,7 +85,22 @@ func clientSetup() (launched bool, listeners []net.Listener) {
+@@ -85,7 +86,22 @@ func clientSetup() (launched bool, listeners []net.Listener) {
  			continue
  		}
  
@@ -63,11 +63,15 @@ index 29c51a3..1555ef6 100644
  		if err != nil {
  			_ = pt.CmethodError(name, err.Error())
  			continue
-@@ -300,22 +315,16 @@ func copyLoop(a net.Conn, b net.Conn) error {
+@@ -300,22 +316,20 @@ func copyLoop(a net.Conn, b net.Conn) error {
  	return nil
  }
  
 -func main() {
++func getVersion() string {
++       return fmt.Sprintf("lyrebird-%s", LyrebirdVersion)
++}
++
 +func Start(meekPort, obfs2Port, obfs3Port, obfs4Port, scramblesuitPort, webtunnelPort *int, logLevelStr *string, enableLogging *bool, unsafeLogging *bool) {
  	// Initialize the termination state monitor as soon as possible.
  	termMon = newTermMonitor()
@@ -92,7 +96,7 @@ index 29c51a3..1555ef6 100644
  	if err := log.SetLogLevel(*logLevelStr); err != nil {
  		golog.Fatalf("[ERROR]: %s - failed to set log level: %s", execName, err)
  	}
-@@ -334,16 +343,15 @@ func main() {
+@@ -334,16 +348,15 @@ func main() {
  		golog.Fatalf("[ERROR]: %s - failed to initialize logging", execName)
  	}
  	if err = transports.Init(); err != nil {
@@ -102,7 +106,7 @@ index 29c51a3..1555ef6 100644
  	}
  
 -	log.Noticef("%s - launched", lyrebirdVersion)
-+	log.Noticef("%s - launched", LyrebirdVersion)
++	log.Noticef("%s - launched", getVersion())
  
  	// Do the managed pluggable transport protocol configuration.
  	if isClient {
@@ -112,7 +116,7 @@ index 29c51a3..1555ef6 100644
  	} else {
  		log.Infof("%s - initializing server transport listeners", execName)
  		launched, ptListeners = serverSetup()
-@@ -375,3 +383,11 @@ func main() {
+@@ -375,3 +388,11 @@ func main() {
  	}
  	termMon.wait(true)
  }


### PR DESCRIPTION
Fix displaying version string format in lyrebird. Lyrebird currently uses the git tag to form it's version string, and getVersion() displays the version string as lyrebird-%s in the same format as the git tag.

This basically reverts 72bd552f248fc955f744a50eb3269c9bb99b5735 "Take the version from git" in lyrebird's sources.