### PR TITLE
bump min android api from 21 to 24

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ cd "$TEMPDIR/IPtProxy.go" || exit 1
 
 gomobile init
 
-MACOSX_DEPLOYMENT_TARGET=11.0 gomobile bind -target=$TARGET -ldflags="-s -w -checklinkname=0" -o "$CURRENT/$OUTPUT" -iosversion=12.0 -androidapi=21 -v -tags=netcgo -trimpath
+MACOSX_DEPLOYMENT_TARGET=11.0 gomobile bind -target=$TARGET -ldflags="-s -w -checklinkname=0" -o "$CURRENT/$OUTPUT" -iosversion=12.0 -androidapi=24 -v -tags=netcgo -trimpath
 
 ### Note:
 # $ go tool link -h


### PR DESCRIPTION
once Orbot returns to directly using IPtProxy we'll want this to match Orbot's min sdk version