### PR TITLE
Add gomobile as a tool

### DIFF
--- a/IPtProxy.go/go.mod
+++ b/IPtProxy.go/go.mod
@@ -84,3 +84,5 @@ require (
 	golang.org/x/tools v0.41.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+tool golang.org/x/mobile/cmd/gomobile

--- a/README.md
+++ b/README.md
@@ -294,8 +294,8 @@ go get gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/goptlib@la
 go get gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird@latest
 go get gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/v2@latest
 go get golang.org/x/net@latest
-go mod tidy
 go get golang.org/x/mobile/cmd/gomobile@latest
+go mod tidy
 ```
 
 A release commit needs the following:


### PR DESCRIPTION
go get -tool golang.org/x/mobile/cmd/gomobile@latest
    
This prevents "go mod tidy" from removing gomobile