### PR TITLE
Make sure TMPDIR exists

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,18 @@
 
 TARGET=ios,iossimulator,macos
 OUTPUT=IPtProxy.xcframework
-TEMPDIR="$(mktemp -d)/IPtProxy"
+
+if test -d "$TMPDIR"; then
+    :
+elif test -d "$TMP"; then
+    TMPDIR=$TMP
+elif test -d /var/tmp; then
+    TMPDIR=/var/tmp
+else
+    TMPDIR=/tmp
+fi
+
+TEMPDIR="$TMPDIR/IPtProxy"
 
 if [ "$1" = "android" ]; then
   TARGET=android


### PR DESCRIPTION
Using mktemp will wind up creating multiple temporary directories after performing several builds.  Each time the build script is executed and the build fails, a different TMPDIR will be used and the previous TMPDIR will not be removed.