### PR TITLE
fix bug with dnstt accept loop and outer waitgroup

### DIFF
--- a/IPtProxy.go/controller.go
+++ b/IPtProxy.go/controller.go
@@ -520,10 +520,13 @@ func (c *Controller) Start(methodName string, proxy string) error {
 
 		go func() {
 			var wg sync.WaitGroup
-
+			wg.Add(1)
 			go dnsttclient.AcceptLoop(ln, utlsClientHelloID, c.shutdown[methodName], &wg)
-
 			wg.Wait()
+			if c.transportEvents != nil {
+				ptlog.Noticef("call OnTransportEvents.Stopped")
+				go c.transportEvents.Stopped(methodName, nil)
+			}
 		}()
 
 		if c.transportEvents != nil {


### PR DESCRIPTION
When debugging https://github.com/guardianproject/orbot-android/pull/1629 I noticed that DNSTT would start in the logs and never stop. 

<img width="947" height="716" alt="image" src="https://github.com/user-attachments/assets/d77bf0a2-de36-4fa7-b96a-4a3a25d36326" />

This is true when trying to ask tor, or when using DNSTT in OrbotService. 

Thinking that there was a bug where dnstt never terminated, I realized it was actually stopping by looking IPtProxy's code and the PT log file stored on Orbot...
```
[NOTICE]: Launched transport: meek_lite
[NOTICE]: Launched transport: dnstt
SOCKS accepted: {tns1.bypasscensorship.org:443 doh=https://dns.google/dns-query;pubkey=c07ae9dd7b86ded6121c3db173de048bfd4f41de38dd430e3dfaf83ec8f36a06;domain=t1.bypasscensorship.org  map[doh:[https://dns.google/dns-query] domain:[t1.bypasscensorship.org] pubkey:[c07ae9dd7b86ded6121c3db173de048bfd4f41de38dd430e3dfaf83ec8f36a06]]}
effective MTU 128
begin session d2ed2e71
begin stream d2ed2e71:3
SOCKS accept error: accept tcp 127.0.0.1:33807: use of closed network connection
[NOTICE]: Shutting down dnstt
Received shutdown signal
end session d2ed2e71
stream d2ed2e71:3 copy stream←local: writeto tcp 127.0.0.1:33807->127.0.0.1:58498: read tcp 127.0.0.1:33807->127.0.0.1:58498: use of closed network connection
end stream d2ed2e71:3
[NOTICE]: Shutting down meek_lite
[NOTICE]: call OnTransportEvents.Stopped
```

So the problem was just that `go c.transportEvents.Stopped(methodName, nil)` was missing for dnstt... But unfortunately, adding this missing event handler call still didn't fix the problem. 

The `sync.WaitGroup` defined in an anon goroutine for dsntt in the controller _always_ immediately finished `wg.Wait()`. This is because the call to `wg.Add(1)` is eventually invoked  in a dnstt goroutine, but by this point it's way  too late because the main IPtController already saw that there's nothing to wait for.  Instead, the waitgroup should be incremented _before_ the goroutine it wants to wait for is invoked. Which this PR does. 

And, the call to wg.Add(1) needs to be removed from the dsntt client accpet loop

```diff
diff --git a/dnstt-client/lib/client.go b/dnstt-client/lib/client.go
index f7dea02..af00ad6 100644
--- a/dnstt-client/lib/client.go
+++ b/dnstt-client/lib/client.go
@@ -137,7 +137,6 @@ func AcceptLoop(ln *pt.SocksListener, utlsClientHelloID *utls.ClientHelloID, shu
                }
                log.Printf("SOCKS accepted: %v", local.Req)
 
-               wg.Add(1)
                go func() {
                        defer func() {
                                _ = local.Close()
```